### PR TITLE
improve: show actual error line when query has error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,11 +65,7 @@ function parseSearchQuery(code: string): ElasticSearchQuery | null {
     let body: Object;
 
     if (jsonBodyStart > -1) {
-      try {
-        body = JSON.parse(code.substring(jsonBodyStart));
-      } catch (e) {
-        body = null
-      }
+      body = code.substring(jsonBodyStart);
     }
 
     return <ElasticSearchQuery>{ method, path, body };
@@ -99,7 +95,7 @@ async function executeQuery(code:string, context: vscode.ExtensionContext, resul
   request(<request.UrlOptions & request.CoreOptions>{
     url: requestUrl,
     method: query.method,
-    json: query.body
+    body: query.body
   }, (error, response, body) => {
     sbi.dispose();
     const endTime = new Date().getTime();
@@ -117,6 +113,16 @@ async function executeQuery(code:string, context: vscode.ExtensionContext, resul
       } else {
         results = body;
       }
+
+      if (response.statusCode == 400) {
+        const matched = results.toString().match(/"line":\s*([0-9]+),/);
+        if (matched != null) {
+          const startLineIndex = code.split('\n').findIndex((line: string) => { return line.indexOf('{') > -1 });
+          const actualLineNumber = Number(matched[1]) + startLineIndex
+          results = results.toString().replace(RegExp('"line": ' + matched[1] + ',', 'g'), '"line": ' + actualLineNumber + ',')
+        }
+      }
+
       results = `[Query Information]
 
 Requested Time  ${new Date(endTime).toLocaleString()}


### PR DESCRIPTION
In current, error line number is fixed 1 when query has error.
This PR is improve that show actual error line number.

For example, below query has syntax error.
```
GET /library/book/_search
{
  "query": {
    "field":{
      "title": "test"
    }
  }
}
```

Current: error line number is fixed 1.
```js
...
[Response]

{
  "error": {
    "root_cause": [
      {
        "type": "parsing_exception",
        "reason": "no [query] registered for [field]",
        "line": 1,
        "col": 19
      }
    ],
    "type": "parsing_exception",
    "reason": "no [query] registered for [field]",
    "line": 1,
    "col": 19
  },
  "status": 400
}
```

After merged this PR:
```js
...
[Response]

{
  "error": {
    "root_cause": [
      {
        "type": "parsing_exception",
        "reason": "no [query] registered for [field]",
        "line": 4,
        "col": 13
      }
    ],
    "type": "parsing_exception",
    "reason": "no [query] registered for [field]",
    "line": 4,
    "col": 13
  },
  "status": 400
}
```

Please consider merging if you do not mind.

regards.